### PR TITLE
Add PHP file type

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -61,6 +61,7 @@ const fileColors = {
   jpg: "#3dc1d3",
   go: "#E67E23",
   rb: "#eb4d4b",
+  php: "#e28f56",
   sh: "#badc58",
   m: "#FFD428",
   py: "#5758BB",


### PR DESCRIPTION
This PR adds the `*.php` file type to support one of the most prevalent server-side languages.

I didn't really know what color to choose, so used something that matched the other server-side languages while still being distinguishable.