### PR TITLE
add missing await

### DIFF
--- a/index.js
+++ b/index.js
@@ -15102,7 +15102,7 @@ var main = async () => {
     core.info("[INFO] No changes to the repo detected, exiting");
     return;
   }
-  (0, import_exec.exec)("git", ["commit", "-m", "Repo visualizer: updated diagram"]);
+  await (0, import_exec.exec)("git", ["commit", "-m", "Repo visualizer: updated diagram"]);
   await (0, import_exec.exec)("git", ["push"]);
   console.log("All set!");
 };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -42,7 +42,7 @@ const main = async () => {
     return
   }
 
-  exec('git', ['commit', '-m', "Repo visualizer: updated diagram"])
+  await exec('git', ['commit', '-m', "Repo visualizer: updated diagram"])
   await exec('git', ['push'])
 
   console.log("All set!")


### PR DESCRIPTION
Addresses issue https://github.com/githubocto/repo-visualizer/issues/9

There was a missing `await` so the action ended up executing the `git push` command before changes were committed.