### PR TITLE
Add F# file extensions colors

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -66,6 +66,8 @@ const fileColors = {
   py: "#5758BB",
   mp4: "#788BA3",
   webm: "#4B6584",
+  fs: "#30B9DB",
+  fsx: "#378BBA",
 };
 const colorThemes = ["file", "changes", "last-change"];
 const colorTheme = "file";


### PR DESCRIPTION
Until we get maybe linguist colors (see #4) I added colors for F# manually.
Because the linguist color was too similiar to JS for me, I decided to use others for now:
I took the two colors from the F# logo and chose the darker one for scripts like it is done for js/jsx, ts/tsx.