### PR TITLE
Start from a subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ For example: dist,node_modules
 
 Default: node_modules,bower_components,dist,out,build,eject,.next,.netlify,.yarn,.vscode,package-lock.json,yarn.lock
 
+
+## `root_path`
+
+The directory you want this action to run into
+
+Default: ./
+
 ## `max_depth`
 
 The maximum number of nested folders to show files within. A higher number will take longer to render.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Default: node_modules,bower_components,dist,out,build,eject,.next,.netlify,.yarn
 
 ## `root_path`
 
-The directory you want this action to run into
+The directory you want this action to run into.
 
 Default: ./
 

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   excluded_paths:
     description: "A list of paths to exclude from the diagram, separated by commas. For example: dist,node_modules"
     required: false
+  root_path:
+    description: "The directory you want this action to run into. Default: ./"
+    required: false
   max_depth:
     description: "The maximum number of nested folders to show files within. Default: 9"
     required: false

--- a/index.js
+++ b/index.js
@@ -17914,13 +17914,14 @@ var main = async () => {
     `${username}@users.noreply.github.com`
   ]);
   core.endGroup();
+  const rootPath = core.getInput("root_path") || "./";
   const maxDepth = core.getInput("max_depth") || 9;
   const colorEncoding = core.getInput("color_encoding") || "type";
   const commitMessage = core.getInput("commit_message") || "Repo visualizer: updated diagram";
   const excludedPathsString = core.getInput("excluded_paths") || "node_modules,bower_components,dist,out,build,eject,.next,.netlify,.yarn,.git,.vscode,package-lock.json,yarn.lock";
   const excludedPaths = excludedPathsString.split(",").map((str) => str.trim());
   const branch = core.getInput("branch");
-  const data = await processDir(`./`, excludedPaths);
+  const data = await processDir(rootPath, excludedPaths);
   const componentCodeString = import_server.default.renderToStaticMarkup(/* @__PURE__ */ import_react3.default.createElement(Tree, {
     data,
     maxDepth: +maxDepth,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -22,13 +22,14 @@ const main = async () => {
   core.endGroup()
 
 
+  const rootPath = core.getInput("root_path") || "./";
   const maxDepth = core.getInput("max_depth") || 9
   const colorEncoding = core.getInput("color_encoding") || "type"
   const commitMessage = core.getInput("commit_message") || "Repo visualizer: updated diagram"
   const excludedPathsString = core.getInput("excluded_paths") || "node_modules,bower_components,dist,out,build,eject,.next,.netlify,.yarn,.git,.vscode,package-lock.json,yarn.lock"
   const excludedPaths = excludedPathsString.split(",").map(str => str.trim())
   const branch = core.getInput("branch")
-  const data = await processDir(`./`, excludedPaths);
+  const data = await processDir(rootPath, excludedPaths);
 
   const componentCodeString = ReactDOMServer.renderToStaticMarkup(
     <Tree data={data} maxDepth={+maxDepth} colorEncoding={colorEncoding} />


### PR DESCRIPTION
I have a project with following structure:
(monorepo-like)
```
MyProject
  - packages
    - client
       ...
    - server
       ...
  package.json
```

I wanted to generate two diagrams: one for `client` and one for `server`.

I've tested it with the following Github Action `yml`:
```
  server_diagram:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout code
        uses: actions/checkout@master

      - name: Update server diagram
        uses: cedric25/repo-visualizer@main
        with:
          root_path: packages/server/src/modules  <-----
          output_file: "server-diagram.svg"
```

It might be a too simple implementation, please don't hesitate to change anything you want!
Or simply close this PR if there is another way to achieve that :)