### PR TITLE
fix(action): fix unhandled promise rejection

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -82,7 +82,9 @@ const main = async () => {
   console.log("All set!")
 }
 
-main()
+main().catch((e) => {
+  core.setFailed(e)
+})
 
 function execWithOutput(command, args) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

This fixes the unhandled promise rejection when something errors out inside `main`. An example would be when one of the git commands fail such as pushing to a write protected branch, you would see this message but the action still passes:
```
(node:1625) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:1625) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

It is fixed by using `core.setFailed` documented [here.](https://github.com/actions/toolkit/tree/main/packages/core#exit-codes)

Related issues: #2 #9 

