### PR TITLE
Change to imperative-style commit message

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -27,7 +27,7 @@ const main = async () => {
   const maxDepth = core.getInput("max_depth") || 9
   const customFileColors = JSON.parse(core.getInput("file_colors") ||  '{}');
   const colorEncoding = core.getInput("color_encoding") || "type"
-  const commitMessage = core.getInput("commit_message") || "Repo visualizer: updated diagram"
+  const commitMessage = core.getInput("commit_message") || "Repo visualizer: update diagram"
   const excludedPathsString = core.getInput("excluded_paths") || "node_modules,bower_components,dist,out,build,eject,.next,.netlify,.yarn,.git,.vscode,package-lock.json,yarn.lock"
   const excludedPaths = excludedPathsString.split(",").map(str => str.trim())
 


### PR DESCRIPTION
Because imperative-style commit messages is recommended and used by almost all major open-source projects.