### PR TITLE
fix: cannot find remote branch

### DIFF
--- a/index.js
+++ b/index.js
@@ -26275,7 +26275,7 @@ var main = async () => {
   const maxDepth = core.getInput("max_depth") || 9;
   const customFileColors = JSON.parse(core.getInput("file_colors") || "{}");
   const colorEncoding = core.getInput("color_encoding") || "type";
-  const commitMessage = core.getInput("commit_message") || "Repo visualizer: updated diagram";
+  const commitMessage = core.getInput("commit_message") || "Repo visualizer: update diagram";
   const excludedPathsString = core.getInput("excluded_paths") || "node_modules,bower_components,dist,out,build,eject,.next,.netlify,.yarn,.git,.vscode,package-lock.json,yarn.lock";
   const excludedPaths = excludedPathsString.split(",").map((str) => str.trim());
   const excludedGlobsString = core.getInput("excluded_globs") || "";
@@ -26295,8 +26295,7 @@ var main = async () => {
   if (branch) {
     await (0, import_exec.exec)("git", ["fetch"]);
     try {
-      await (0, import_exec.exec)("git", ["rev-parse", "--verify", branch]);
-      await (0, import_exec.exec)("git", ["checkout", branch]);
+      await (0, import_exec.exec)("git", ["switch", "-c", branch, "--track", `origin/${branch}`]);
     } catch {
       doesBranchExist = false;
       core.info(`Branch ${branch} does not yet exist, creating ${branch}.`);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -54,8 +54,7 @@ const main = async () => {
     await exec('git', ['fetch'])
 
     try {
-      await exec('git', ['rev-parse', '--verify', branch])
-      await exec('git', ['checkout', branch])
+      await exec('git', ['switch', '-c' , branch,'--track', `origin/${branch}`])
     } catch {
       doesBranchExist = false
       core.info(`Branch ${branch} does not yet exist, creating ${branch}.`)


### PR DESCRIPTION
Hi, 

Thank you for this amazing library! In terms of getting a fingerprint of the project and its structure, there is nothing that I have come across that is easier to use. 

While running this action in one of my repos I faced the following issue which this PR resolves

```
/usr/bin/git rev-parse --verify <branch-name>
fatal: Needed a single revision
```

and there after pushing fails since it tries to push to a branch that already exists

```
  /usr/bin/git push --set-upstream origin <branch-name>
  To https://github.com/<org>/<repo-name>
   ! [rejected]        visualizer -> visualizer (non-fast-forward)
  error: failed to push some refs to 'https://github.com/<org>/<repo-name>'
  hint: Updates were rejected because the tip of your current branch is behind
  hint: its remote counterpart. Integrate the remote changes (e.g.
  hint: 'git pull ...') before pushing again.
  hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```

Changing to git switch with the --track flag solves the problem. 