### PR TITLE
Update to node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ outputs:
   svg:
     description: "The diagram contents as text"
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"
 branding:
   color: "purple"


### PR DESCRIPTION
Solves the following warning:

<img width="1268" alt="image" src="https://user-images.githubusercontent.com/1174877/202875297-58ab2e44-09f3-4659-829f-943f018c360a.png">
